### PR TITLE
fix: change selector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ impl Jobcan {
     pub fn punch_in(&self, tab: &Arc<Tab>) -> Result<String, failure::Error> {
         let before_status = self.get_status(&tab)?;
 
-        tab.wait_for_element_with_custom_timeout("span#adit-button-push", Duration::from_secs(60))?
+        tab.wait_for_element_with_custom_timeout("#adit-button-push", Duration::from_secs(60))?
             .click()?;
         thread::sleep(Duration::from_secs(3));
 


### PR DESCRIPTION
打刻ボタンの要素が `span` から `button` に変更されていました。
idだけで指定できそうだったので `span` を消しました:pray: